### PR TITLE
Fix/56-database-read

### DIFF
--- a/src/Firebase.Database/Database.uno
+++ b/src/Firebase.Database/Database.uno
@@ -287,31 +287,15 @@ namespace Firebase.Database
             [[ref child:path] observeSingleEventOfType:FIRDataEventTypeValue withBlock:^(FIRDataSnapshot * _Nonnull snapshot) {
                 NSError *error;
 
-                if([snapshot.value isEqual:[NSNull null]])
-                {
-                    @{Read:Of(_this).Resolve(string):Call(nil)};
-                    return;
-                }
-
-                NSData *jsonData;
-                if ([snapshot.value isKindOfClass:[NSString class]])
-                {
-                    NSString *jsonstring = [NSString stringWithFormat:@"\"%@\"", snapshot.value];
-                    @{Read:Of(_this).Resolve(string):Call(jsonstring)};
-
-                    // NSData *data = [snapshot.value dataUsingEncoding:NSUTF8StringEncoding];
-                    // jsonData = [NSJSONSerialization JSONObjectWithData:data
-                    //                                              options:(NSJSONWritingOptions)0
-                    //                                                error:&error];
-                }
-                else
-                {
-                    jsonData = [NSJSONSerialization dataWithJSONObject:snapshot.value
-                                                                  options:(NSJSONWritingOptions)0
-                                                                    error:&error];
-                    NSString *json = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
-                    @{Read:Of(_this).Resolve(string):Call(json)};
-                }
+                @{Read:Of(_this).Resolve(string):Call((
+                    ([snapshot.value isEqual:[NSNull null]])
+                        ? nil
+                        : ([snapshot.value isKindOfClass:[NSString class]])
+                            ? [NSString stringWithFormat:@"\"%@\"", snapshot.value]
+                            : ([snapshot.value isKindOfClass:[NSNumber class]])
+                                ? [NSString stringWithFormat:@"%@", snapshot.value]
+                                : [[NSString alloc] initWithData:[NSJSONSerialization dataWithJSONObject:snapshot.value options:(NSJSONWritingOptions)0 error:&error] encoding:NSUTF8StringEncoding]
+                ))};
 
               } withCancelBlock:^(NSError * _Nonnull error) {
                   NSString *erstr = [NSString stringWithFormat:@"Firebase Read Error: %@", error.localizedDescription];

--- a/src/Firebase.Database/Database.uno
+++ b/src/Firebase.Database/Database.uno
@@ -328,7 +328,9 @@ namespace Firebase.Database
         "com.google.firebase.database.DataSnapshot",
         "com.google.firebase.database.ValueEventListener",
         "org.json.JSONObject",
-        "java.util.Map")]
+        "org.json.JSONArray",
+        "java.util.Map",
+        "java.util.List")]
     extern(Android)
     internal class Read : Promise<string>
     {
@@ -339,8 +341,18 @@ namespace Firebase.Database
                 @Override
                 public void onDataChange(DataSnapshot dataSnapshot)
                 {
-                    JSONObject json = new JSONObject((Map)dataSnapshot.getValue());
-                    @{Read:Of(_this).Resolve(string):Call(json.toString())};
+                    Object snapshotValue = dataSnapshot.getValue();
+                    @{Read:Of(_this).Resolve(string):Call((
+                        (snapshotValue == null)
+                            ? null
+                            : (snapshotValue instanceof Map)
+                                ? new JSONObject((Map) snapshotValue).toString()
+                                : (snapshotValue instanceof List)
+                                    ? new JSONArray((List) snapshotValue).toString()
+                                    : (snapshotValue instanceof String)
+                                        ? "\"" + snapshotValue.toString() + "\""
+                                        : snapshotValue.toString()
+                    ))};
                 }
 
                 @Override


### PR DESCRIPTION
- Made Android version of Firebase.Database.read compatible with nulls, lists and primitive types
- Made iOS version of Firebase.Database.read compatible with booleans and numbers, and cleaned up the iOS code for Read in Database.uno

Fixes #56