### PR TITLE
Database now configures Firebase app & Analytics update

### DIFF
--- a/AnalyticsExample/AnalyticsExample.unoproj
+++ b/AnalyticsExample/AnalyticsExample.unoproj
@@ -5,7 +5,8 @@
   ],
   "Projects": [
     "../src/Firebase/Firebase.unoproj",
-    "../src/Firebase.Analytics/Firebase.Analytics.unoproj",
+    "../src/Firebase.Database/Firebase.Database.unoproj",
+    "../src/Firebase.Analytics/Firebase.Analytics.unoproj"
   ],
   "Includes": [
     "*",

--- a/AuthExample/AuthExample.unoproj
+++ b/AuthExample/AuthExample.unoproj
@@ -6,6 +6,7 @@
   ],
   "Projects": [
     "../src/Firebase/Firebase.unoproj",
+    "../src/Firebase.Database/Firebase.Database.unoproj",
     "../src/Firebase.Authentication/Firebase.Authentication.unoproj",
     "../src/Firebase.Authentication.Email/Firebase.Authentication.Email.unoproj",
     "../src/Firebase.Authentication.Google/Firebase.Authentication.Google.unoproj",

--- a/src/Firebase.Analytics/Analytics.uno
+++ b/src/Firebase.Analytics/Analytics.uno
@@ -42,8 +42,8 @@ namespace Firebase.Analytics
         @}
 
 
-        [Require("Source.Import","FirebaseAnalytics/FIRApp.h")]
         [Require("Source.Import","FirebaseAnalytics/FirebaseAnalytics.h")]
+        [Require("Xcode.Framework", "AdSupport.framework")]
         [Foreign(Language.ObjC)]
         extern(iOS)
         public static void LogEvent(string name, string[] keys, string[] vals, int len)

--- a/src/Firebase.Analytics/Analytics.uno
+++ b/src/Firebase.Analytics/Analytics.uno
@@ -20,15 +20,6 @@ namespace Firebase.Analytics
         static bool _initialized;
         extern(android) static Java.Object _handle;
 
-        public static void Init()
-        {
-            if (!_initialized)
-            {
-                Firebase.Core.Init();
-                if defined(android) AndroidInit();
-                _initialized = true;
-            }
-        }
 
         [Foreign(Language.Java)]
         extern(android)

--- a/src/Firebase.Analytics/JS.uno
+++ b/src/Firebase.Analytics/JS.uno
@@ -24,7 +24,6 @@ namespace Firebase.Analytics.JS
             if(_instance != null) return;
             Uno.UX.Resource.SetGlobalKey(_instance = this, "Firebase/Analytics");
 
-            AnalyticsService.Init();
             AddMember(new NativeFunction("logEvent", LogEvent));
         }
 

--- a/src/Firebase/Core.uno
+++ b/src/Firebase/Core.uno
@@ -10,40 +10,41 @@ using Fuse.Controls.Native.Android;
 
 namespace Firebase
 {
-    [ForeignInclude(Language.Java, "java.util.ArrayList", "java.util.List", "android.graphics.Color")]
-    [Require("Gradle.Dependency.ClassPath", "com.google.gms:google-services:3.0.0")]
-    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-core:9.2.0")]
-    [Require("Gradle.BuildFile.End", "apply plugin: 'com.google.gms.google-services'")]
-
-    [Require("Cocoapods.Podfile.Target", "pod 'Firebase/Core'")]
-    [Require("Cocoapods.Podfile.Target", "pod 'FirebaseAnalytics'")]
-    [extern(iOS) Require("Source.Include", "Firebase/Firebase.h")]
+    extern(!mobile)
     public class Core
     {
-        static bool _initialized;
+        static public void Init() {}
+    }
 
-        public static void Init()
-        {
-            if (!_initialized)
-            {
-                InitImpl();
-                _initialized = true;
-            }
-        }
-        extern(!mobile)
-        static public void InitImpl() { }
-
+    [Require("Cocoapods.Podfile.Target", "pod 'Firebase/Core'")]
+    [Require("Cocoapods.Podfile.Target", "pod 'Firebase/Messaging'")]
+    [Require("Source.Include", "Firebase/Firebase.h")]
+    extern(iOS)
+    public class Core
+    {
         [Foreign(Language.ObjC)]
-        extern(iOS)
-        static public void InitImpl()
-        @{
-            [FIRApp configure];
-        @}
+        static public void Init()
+        {
+                @{
+                    NSLog(@"Firebase Configuring...");
+                    [FIRApp configure];
+                    NSLog(@"Firebase Configure Ready!");
+                @}
+        }
+    }
 
+    [ForeignInclude(Language.Java, "java.util.ArrayList", "java.util.List", "android.graphics.Color")]
+    [Require("Gradle.Dependency.ClassPath", "com.google.gms:google-services:3.0.0")]
+    [Require("Gradle.AllProjects.Repository", "maven {url 'https://maven.google.com'}")]
+    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-core:11.8.0")]
+    [Require("Gradle.BuildFile.End", "apply plugin: 'com.google.gms.google-services'")]
+    extern(Android)
+    public class Core
+    {
         [Foreign(Language.Java)]
-        extern(Android)
-        static public void InitImpl()
+        static public void Init()
         @{
+
         @}
     }
 }


### PR DESCRIPTION
Big change and #78 fix

- Database now configures the Firebase app. This prevents multiple configurations causing the app to crash. You must now add Database all the time and then add  Storage, Analytics or whatever you need
- Firebase updated their SDKs so this is no longed used. Also, Ad support framework is now added by default. This allows you to get more in-depth data like gender, age and more.

For more info see: https://firebase.google.com/support/guides/analytics-adsupport