### PR TITLE
Firebase SDK update 12.0.1

### DIFF
--- a/src/Firebase.AdMob/AndroidImpl.uno
+++ b/src/Firebase.AdMob/AndroidImpl.uno
@@ -16,7 +16,7 @@ using Firebase.AdMob;
 namespace Firebase.AdMob
 {
 
-    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-ads:11.8.0")]
+    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-ads:12.0.1")]
     [ForeignInclude(Language.Java,
                     "com.google.android.gms.ads.AdRequest",
                     "com.google.android.gms.ads.AdSize",

--- a/src/Firebase.Authentication.Email/AndroidImpl.uno
+++ b/src/Firebase.Authentication.Email/AndroidImpl.uno
@@ -18,7 +18,7 @@ namespace Firebase.Authentication.Email
                     "com.google.firebase.auth.AuthResult",
                     "com.google.firebase.auth.FirebaseAuth",
                     "com.google.firebase.auth.FirebaseUser")]
-    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-auth:11.8.0")]
+    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-auth:12.0.1")]
     extern(android)
     internal class CreateUser : Promise<string>
     {
@@ -60,7 +60,7 @@ namespace Firebase.Authentication.Email
                     "com.google.firebase.auth.AuthResult",
                     "com.google.firebase.auth.FirebaseAuth",
                     "com.google.firebase.auth.FirebaseUser")]
-    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-auth:11.8.0")]
+    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-auth:12.0.1")]
     extern(android)
     internal class SignInUser : Promise<string>
     {
@@ -103,7 +103,7 @@ namespace Firebase.Authentication.Email
                     "com.google.firebase.auth.EmailAuthProvider",
                     "com.google.firebase.auth.AuthCredential",
                     "com.google.firebase.auth.UserProfileChangeRequest")]
-    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-auth:11.8.0")]
+    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-auth:12.0.1")]
     extern(android)
     internal class ReAuthenticate : Promise<string>
     {

--- a/src/Firebase.Authentication.Google/Authentication.uno
+++ b/src/Firebase.Authentication.Google/Authentication.uno
@@ -30,8 +30,8 @@ namespace Firebase.Authentication.Google
                     "com.google.firebase.auth.FirebaseAuth",
                     "com.google.firebase.auth.FirebaseUser",
                     "com.google.firebase.auth.GoogleAuthProvider")]
-    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-auth:11.8.0")]
-    [Require("Gradle.Dependency.Compile", "com.google.android.gms:play-services-auth:11.8.0")]
+    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-auth:12.0.1")]
+    [Require("Gradle.Dependency.Compile", "com.google.android.gms:play-services-auth:12.0.1")]
     [Require("Cocoapods.Podfile.Target", "pod 'GoogleSignIn'")]
     [Require("AppDelegate.HeaderFile.Declaration", "#include <GoogleSignIn/GoogleSignIn.h>")]
     [Require("AppDelegate.SourceFile.Declaration", "#include <GoogleSignIn/GoogleSignIn.h>")]

--- a/src/Firebase.Authentication/Authentication.uno
+++ b/src/Firebase.Authentication/Authentication.uno
@@ -20,7 +20,7 @@ namespace Firebase.Authentication
                     "com.google.firebase.auth.AuthResult",
                     "com.google.firebase.auth.FirebaseAuth",
                     "com.google.firebase.auth.FirebaseUser")]
-    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-auth:11.8.0")]
+    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-auth:12.0.1")]
     [Require("AppDelegate.SourceFile.Declaration", "#include <@{Firebase.Authentication.AuthService:Include}>")]
     [extern(iOS) Require("Source.Include", "Firebase/Firebase.h")]
     [extern(iOS) Require("Source.Include", "FirebaseAuth/FirebaseAuth.h")]

--- a/src/Firebase.Database/Database.uno
+++ b/src/Firebase.Database/Database.uno
@@ -26,7 +26,7 @@ namespace Firebase.Database
         "java.util.Map",
         "java.util.HashMap")]
     [Require("Cocoapods.Podfile.Target", "pod 'Firebase/Database'")]
-    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-database:11.8.0")]
+    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-database:12.0.1")]
     [extern(iOS) Require("Source.Import","FirebaseDatabase/FIRDatabase.h")]
     extern(mobile)
     static class DatabaseService

--- a/src/Firebase.Notifications.Android/Android/Impl.uno
+++ b/src/Firebase.Notifications.Android/Android/Impl.uno
@@ -23,7 +23,7 @@ namespace Firebase.Notifications
                     "android.os.Bundle",
                     "com.fuse.firebase.Notifications.PushNotificationReceiver",
                     "com.google.firebase.messaging.RemoteMessage")]
-    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-messaging:11.8.0")]
+    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-messaging:12.0.1")]
     extern(Android)
     internal class AndroidImpl
     {

--- a/src/Firebase.Storage/Storage.uno
+++ b/src/Firebase.Storage/Storage.uno
@@ -17,7 +17,7 @@ namespace Firebase.Storage
         "com.google.firebase.storage.StorageReference",
         "com.google.firebase.storage.UploadTask")]
     [Require("Cocoapods.Podfile.Target", "pod 'Firebase/Storage'")]
-    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-storage:11.8.0")]
+    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-storage:12.0.1")]
     [extern(iOS) Require("Source.Import","FirebaseStorage/FirebaseStorage.h")]
     extern(mobile)
     static class StorageService

--- a/src/Firebase/Core.uno
+++ b/src/Firebase/Core.uno
@@ -36,7 +36,7 @@ namespace Firebase
     [ForeignInclude(Language.Java, "java.util.ArrayList", "java.util.List", "android.graphics.Color")]
     [Require("Gradle.Dependency.ClassPath", "com.google.gms:google-services:4.0.0")]
     [Require("Gradle.AllProjects.Repository", "maven {url 'https://maven.google.com'}")]
-    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-core:11.8.0")]
+    [Require("Gradle.Dependency.Compile", "com.google.firebase:firebase-core:12.0.1")]
     [Require("Gradle.BuildFile.End", "apply plugin: 'com.google.gms.google-services'")]
     extern(Android)
     public class Core


### PR DESCRIPTION
*Firebase 12.0*
Fixes a regression that caused custom notification icons to be rejected on Android 8.0

*Firebase 12.0.1*
-license POM dependencies caused "more than one library with package name ‘com.google.android.gms.license'" issues in Ionic Pro. (Also in Fuse-Open)

Also fixes #69 