### PR TITLE
travis updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ jobs:
 
     - stage: build 
       name: "Building Android"
+      osx_image: xcode9.3
       before_script:
-        - printf '\ny' | fuse install android;
+        - printf '\ny' | fuse install android
       script:
         - uno build TravisTest -tAndroid -n=-quiet
 


### PR DESCRIPTION
I do not know why but `printf '\ny' | fuse install android` fails on `xcode 9.4` image and since that is the new default ([blog post](https://blog.travis-ci.com/2018-07-19-xcode9-4-default-announce)) we must declare `xcode 9.3`