### PR TITLE
New property: providerData

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -161,6 +161,16 @@ console.log(FirebaseUser.photoUrl);
 ```
 
 
+### Property - providerData
+
+This property returns the provider data associated with the authenticated user
+
+#### Example
+```js
+console.log(FirebaseUser.providerData);
+```
+
+
 ### Function - updateProfile(newDisplayNameString, newPhotoUrlString)
 
 This function attempts to update the `displayName` and `photoUrl` of the authenticated user.

--- a/src/Firebase.Authentication/AndroidImpl.uno
+++ b/src/Firebase.Authentication/AndroidImpl.uno
@@ -19,7 +19,8 @@ namespace Firebase.Authentication
                     "com.google.firebase.auth.FirebaseUser",
                     "com.google.firebase.auth.UserInfo",
                     "org.json.JSONArray",
-                    "org.json.JSONObject")]
+                    "org.json.JSONObject",
+                    "org.json.JSONException")]
     extern(android)
     internal static class User
     {
@@ -65,8 +66,20 @@ namespace Firebase.Authentication
         internal static string GetProviderData(Java.Object obj)
         @{
             FirebaseUser user = (FirebaseUser)obj;
-            JSONArray JSONArray = new JSONArray(user.getProviderData());
-            return JSONArray.toString();
+            JSONArray providers = new JSONArray();
+            for (UserInfo profile : user.getProviderData()) {
+                JSONObject provider = new JSONObject();
+                try {
+                    provider.put("getProviderId", profile.getProviderId());
+                    provider.put("getDisplayName", profile.getDisplayName());
+                    provider.put("getEmail", profile.getEmail());
+                    provider.put("getUid", profile.getUid());
+                    providers.put(provider);
+                } catch (JSONException e) {
+                    //
+                }
+            }
+            return providers.toString();
         @}
 
         [Foreign(Language.Java)]

--- a/src/Firebase.Authentication/AndroidImpl.uno
+++ b/src/Firebase.Authentication/AndroidImpl.uno
@@ -16,7 +16,10 @@ namespace Firebase.Authentication
                     "com.google.android.gms.tasks.Task",
                     "com.google.firebase.auth.AuthResult",
                     "com.google.firebase.auth.FirebaseAuth",
-                    "com.google.firebase.auth.FirebaseUser")]
+                    "com.google.firebase.auth.FirebaseUser",
+                    "com.google.firebase.auth.UserInfo",
+                    "org.json.JSONArray",
+                    "org.json.JSONObject")]
     extern(android)
     internal static class User
     {
@@ -56,6 +59,14 @@ namespace Firebase.Authentication
             FirebaseUser user = (FirebaseUser)obj;
             Uri uri = user.getPhotoUrl();
             return (uri==null) ? null : uri.toString();
+        @}
+
+        [Foreign(Language.Java)]
+        internal static string GetProviderData(Java.Object obj)
+        @{
+            FirebaseUser user = (FirebaseUser)obj;
+            JSONArray JSONArray = new JSONArray(user.getProviderData());
+            return JSONArray.toString();
         @}
 
         [Foreign(Language.Java)]

--- a/src/Firebase.Authentication/Authentication.uno
+++ b/src/Firebase.Authentication/Authentication.uno
@@ -257,6 +257,7 @@ namespace Firebase.Authentication
         internal static string GetName(object obj) { return null; }
         internal static string GetEmail(object obj) { return null; }
         internal static string GetPhotoUrl(object obj) { return null; }
+        internal static string GetProviderData(object obj) { return null; }
         internal static void GetToken(object obj, Action<string> gotToken) { gotToken(null); }
         internal static bool IsEmailVerified(object obj) { return false; }
     }

--- a/src/Firebase.Authentication/JS.uno
+++ b/src/Firebase.Authentication/JS.uno
@@ -35,6 +35,7 @@ namespace Firebase.Authentication.JS
             AddMember(new NativeProperty<string, string>("name", GetName));
             AddMember(new NativeProperty<string, string>("email", GetEmail));
             AddMember(new NativeProperty<string, string>("photoUrl", GetPhotoUrl));
+            AddMember(new NativeProperty<string, string>("providerData", GetProviderData));
             AddMember(new NativeProperty<bool, bool>("isEmailVerified", IsEmailVerified));
 
             // events
@@ -96,6 +97,14 @@ namespace Firebase.Authentication.JS
         {
             if (GetSignedIn())
                 return User.GetPhotoUrl(User.GetCurrent());
+            else
+                return "";
+        }
+
+        static string GetProviderData()
+        {
+            if (GetSignedIn())
+                return User.GetProviderData(User.GetCurrent());
             else
                 return "";
         }

--- a/src/Firebase.Authentication/iOSImpl.uno
+++ b/src/Firebase.Authentication/iOSImpl.uno
@@ -55,6 +55,22 @@ namespace Firebase.Authentication
         @}
 
         [Foreign(Language.ObjC)]
+        internal static string GetProviderData(ObjC.Object obj)
+        @{
+            FIRUser* user = [FIRAuth auth].currentUser;
+            NSMutableArray *providers = [[NSMutableArray alloc] init];
+
+            NSArray<id<FIRUserInfo>> *providerData = user.providerData;
+            for (id<FIRUserInfo> userInfo in providerData) {
+                NSDictionary *dict = @{ @"providerID" : userInfo.providerID, @"displayName" : userInfo.displayName, @"email" : userInfo.email, @"uid" : userInfo.uid};
+                [providers addObject:dict];
+            }
+
+            NSData *jsonData = [NSJSONSerialization dataWithJSONObject:providers options:0 error:nil];
+            return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+        @}
+
+        [Foreign(Language.ObjC)]
         internal static bool IsEmailVerified(ObjC.Object obj)
         @{
             FIRUser* user = [FIRAuth auth].currentUser;


### PR DESCRIPTION
As requested in #103 `FirebaseUser` now has a new property called `providerData` which returns data from all providers associated with the user.

Example:
```js
console.log(FirebaseUser.providerData);
```